### PR TITLE
✨ Quality: Incorrect em-to-pixel calculation formula

### DIFF
--- a/src/AtomUI.Core/Media/FontUtils.cs
+++ b/src/AtomUI.Core/Media/FontUtils.cs
@@ -12,6 +12,6 @@ public static class FontUtils
    public static double ConvertEmToPixel(double value, double fontSize, double renderScaling = 1.0)
     {
         var fontSizePx = fontSize * value * renderScaling;
-        return fontSizePx * value;
+        return fontSizePx;
     }
 }


### PR DESCRIPTION
## Problem

The `ConvertEmToPixel` method incorrectly multiplies by `value` twice instead of using `value` as the em unit multiplier.
The formula `fontSizePx * value` should be `fontSize * value * renderScaling`, but it's currently `(fontSize * value * renderScaling) * value`.
This will cause all text measurements using em units to be scaled incorrectly by the square of the intended value, leading to visual layout bugs.


**Severity**: `high`
**File**: `src/AtomUI.Core/Media/FontUtils.cs`

## Solution

Change line 17 from:
    return fontSizePx * value;
To:
    return fontSizePx;


## Changes

- `src/AtomUI.Core/Media/FontUtils.cs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
