### PR TITLE
📝 Docs: FontUtils.ConvertEmToPixel has incorrect calculation formula

### DIFF
--- a/src/AtomUI.Core/Media/FontUtils.cs
+++ b/src/AtomUI.Core/Media/FontUtils.cs
@@ -5,13 +5,12 @@ public static class FontUtils
    /// <summary>
    /// 将 value 的值转换为像素
    /// </summary>
-   /// <param name="value"></param>
-   /// <param name="fontSize"></param>
-   /// <param name="renderScaling"></param>
-   /// <returns></returns>
+   /// <param name="value">EM 单位值</param>
+   /// <param name="fontSize">基础字体大小（像素）</param>
+   /// <param name="renderScaling">渲染缩放比例，默认为 1.0</param>
+   /// <returns>转换后的像素值</returns>
    public static double ConvertEmToPixel(double value, double fontSize, double renderScaling = 1.0)
     {
-        var fontSizePx = fontSize * value * renderScaling;
-        return fontSizePx * value;
+        return fontSize * value * renderScaling;
     }
 }


### PR DESCRIPTION
## Problem

The method incorrectly multiplies by `value` twice: `fontSize * value * renderScaling` then `* value` again.
This results in pixels = fontSize * value² * renderScaling instead of the correct fontSize * value * renderScaling.
This is a mathematical bug that will cause incorrect font size calculations throughout the library.


**Severity**: `high`
**File**: `src/AtomUI.Core/Media/FontUtils.cs`

## Solution

Change line 15 from:
    var fontSizePx = fontSize * value * renderScaling;
    return fontSizePx * value;
To:
    return fontSize * value * renderScaling;


## Changes

- `src/AtomUI.Core/Media/FontUtils.cs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
