### PR TITLE
fix(Dialog): close dialog on cancellation to prevent zombie state

### DIFF
--- a/src/AtomUI.Desktop.Controls/Dialog/Dialog.cs
+++ b/src/AtomUI.Desktop.Controls/Dialog/Dialog.cs
@@ -541,26 +541,34 @@ public partial class Dialog : TemplatedControl,
                     SetCurrentValue(IsOpenProperty, true);
                 }
 
-                if (dialogHost is DialogHost windowDialog &&
+                try
+                {
+                    if (dialogHost is DialogHost windowDialog &&
                     IsModal &&
                     topLevel is Window ownerWindow &&
                     RuntimePlatform.Features.SupportsWindowModalDialog)
-                {
-                    // Window 宿主 + modal：必须用 ShowDialog() 拿 OS 级 modal 语义
-                    // （父窗禁用、焦点限制、macOS 下表现为 sheet）。
-                    // 仅用 Show() 再 await ClosedTask 只是应用层等待，父窗仍然可交互。
-                    Opened?.Invoke(this, EventArgs.Empty);
-                    await windowDialog.ShowDialog(ownerWindow).WaitAsync(cancellationToken);
-                }
-                else
-                {
-                    dialogHost.Show();
-                    Opened?.Invoke(this, EventArgs.Empty);
-
-                    if (IsModal)
                     {
-                        await openState.ClosedTask.WaitAsync(cancellationToken);
+                        // Window 宿主 + modal：必须用 ShowDialog() 拿 OS 级 modal 语义
+                        // （父窗禁用、焦点限制、macOS 下表现为 sheet）。
+                        // 仅用 Show() 再 await ClosedTask 只是应用层等待，父窗仍然可交互。
+                        Opened?.Invoke(this, EventArgs.Empty);
+                        await windowDialog.ShowDialog(ownerWindow).WaitAsync(cancellationToken);
                     }
+                    else
+                    {
+                        dialogHost.Show();
+                        Opened?.Invoke(this, EventArgs.Empty);
+
+                        if (IsModal)
+                        {
+                            await openState.ClosedTask.WaitAsync(cancellationToken);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    dialogHost.Close();
+                    throw;
                 }
             }
             catch when (!ownershipTransferred)


### PR DESCRIPTION
修复任务取消，抛出异常时，因没有调用DialogHost.Close()导致的Dialog状态异常。

BUG示例：
<img width="1479" height="77" alt="image" src="https://github.com/user-attachments/assets/8da9f324-4ddd-4fff-ae75-1247ca3cc776" />

https://github.com/user-attachments/assets/9541f1c3-f256-40f9-8a56-eb5c33625bc7

catch并且Close之后：

https://github.com/user-attachments/assets/5a1fc9f2-b98f-4bbc-9f80-a4658e2403ff

