### PR TITLE
fix(DataGrid): fix InvalidOperationException when drag state reset by…

### DIFF
--- a/src/AtomUI.Desktop.Controls.DataGrid/Column/DataGridRowReorderHandle.cs
+++ b/src/AtomUI.Desktop.Controls.DataGrid/Column/DataGridRowReorderHandle.cs
@@ -61,7 +61,10 @@ internal class DataGridRowReorderHandle : TemplatedControl
         Debug.Assert(rowsPresenter != null);
         Debug.Assert(OwningRow != null);
 
-        if (_dragRowIndex == null)
+        var dragRowIndex = _dragRowIndex;
+        var currentDraggingOverRowIndex = _currentDraggingOverRowIndex;
+
+        if (dragRowIndex == null)
         {
             ResetDragState(rowsPresenter, invalidateArrange: false);
             return;
@@ -77,28 +80,25 @@ internal class DataGridRowReorderHandle : TemplatedControl
         {
             _indicatorButton.DisableTransitions();
         }
-        if (_currentDraggingOverRowIndex != null && _currentDraggingOverRowIndex != _dragRowIndex)
+        if (currentDraggingOverRowIndex != null && currentDraggingOverRowIndex != dragRowIndex)
         {
             if (OwningGrid.CollectionView is IList collectionView)
             {
-                if (_dragRowIndex != null)
+                var data = collectionView[dragRowIndex.Value];
+                if (data is not null)
                 {
-                    var data = collectionView[_dragRowIndex.Value];
-                    if (data is not null)
-                    {
-                        collectionView.RemoveAt(_dragRowIndex.Value);
-                        collectionView.Insert(_currentDraggingOverRowIndex.Value, data);
-                    }
+                    collectionView.RemoveAt(dragRowIndex.Value);
+                    collectionView.Insert(currentDraggingOverRowIndex.Value, data);
                 }
-               
-                if (_indicatorButton != null)
-                {
-                    _indicatorButton.EnableTransitions();
-                }
-                OwningGrid.CollectionView.Refresh();
             }
+
+            if (_indicatorButton != null)
+            {
+                _indicatorButton.EnableTransitions();
+            }
+            OwningGrid.CollectionView?.Refresh();
         }
-        
+
         ResetDragState(rowsPresenter, invalidateArrange: true);
     }
 


### PR DESCRIPTION
### 拖拽DataGrid行时，释放鼠标按键后程序抛出未捕获的异常
```
CrashTime: 2026/7/30 22:43:10
Exception Type: InvalidOperationException
Exception Message: Nullable object must have a value.
Stack Info: 
   at System.Nullable`1.get_Value()
   at AtomUI.Desktop.Controls.DataGridRowReorderHandle.OnPointerReleased(PointerReleasedEventArgs e) in ***\AtomUI\src\AtomUI.Desktop.Controls.DataGrid\Column\DataGridRowReorderHandle.cs:line 90
   at Avalonia.Reactive.LightweightObservableBase`1.PublishNext(T value)
   at Avalonia.Interactivity.EventRoute.RaiseEventImpl(RoutedEventArgs e)
   at Avalonia.Interactivity.EventRoute.RaiseEvent(Interactive source, RoutedEventArgs e)
   at Avalonia.Interactivity.Interactive.RaiseEvent(RoutedEventArgs e)
   at Avalonia.Input.MouseDevice.MouseUp(IMouseDevice device, UInt64 timestamp, IInputRoot root, Point p, PointerPointProperties props, KeyModifiers inputModifiers, IInputElement hitTest)
   at Avalonia.Input.MouseDevice.ProcessRawEvent(RawPointerEventArgs e)
   at Avalonia.Input.InputManager.ProcessInput(RawInputEventArgs e)
   at Avalonia.Threading.Dispatcher.Send(SendOrPostCallback action, Object arg, Nullable`1 priority)
   at Avalonia.Controls.PresentationSource.HandleInput(RawInputEventArgs e)
   at Avalonia.Win32.WindowImpl.AppWndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam)
   at Avalonia.Win32.WindowImpl.WndProcMessageHandler(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam)
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32DispatcherImpl.RunLoop(CancellationToken cancellationToken)
   at Avalonia.Threading.DispatcherFrame.Run(IControlledDispatcherImpl impl)
   at Avalonia.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.StartCore(String[] args)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, Action`1 lifetimeBuilder)
   at AtomUIGallery.Desktop.Program.Main(String[] args) in ***\AtomUI\controlgallery\AtomUIGallery.Desktop\Program.cs:line 14
```

#### 问题描述: 
在 `DataGridRowReorderHandle.OnPointerReleased` 中, 触发 `NotifyRowReordered` 事件后，静态字段 `_dragRowIndex` 可能被事件处理程序重置为 `null`, 导致后续访问 `_dragRowIndex.Value` 时引发 `InvalidOperationException`

#### 修复方案: 
- 在调用 `NotifyRowReordered` 前, 将 `_dragRowIndex` 和 `_currentDraggingOverRowIndex` 复制到局部变量
- 后续逻辑均使用缓存的局部变量, 避免依赖可能被修改的静态字段
